### PR TITLE
Use  keys.gnupg.net instead

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -46,7 +46,7 @@ def main():
 					''')
 					repo = raw_input("\033[1;32mWhat do you want to do ?> \033[1;m")
 					if repo == "1":
-						cmd1 = os.system("apt-key adv --keyserver pgp.mit.edu --recv-keys ED444FF07D8D0BF6")
+						cmd1 = os.system("apt-key adv --keyserver hkp://keys.gnupg.net --recv-keys ED444FF07D8D0BF6")
 						cmd2 = os.system("echo '# Kali linux repositories | Added by Katoolin\ndeb http://http.kali.org/kali kali-rolling main contrib non-free' >> /etc/apt/sources.list")
 					elif repo == "2":
 						cmd3 = os.system("apt-get update -m")


### PR DESCRIPTION
I was unable to add the public key with the mit service, changing it to this new service made it work for me.
Suggestion got from: http://unix.stackexchange.com/a/223398