### PR TITLE
UPDATE :  kali-archive-keyring 2018.1

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -46,7 +46,7 @@ def main():
 					''')
 					repo = raw_input("\033[1;32mWhat do you want to do ?> \033[1;m")
 					if repo == "1":
-						cmd1 = os.system("apt-key adv --keyserver pgp.mit.edu --recv-keys ED444FF07D8D0BF6")
+						cmd1 = os.system("apt-key adv --keyserver hkp://keys.gnupg.net --recv-keys 7D8D0BF6")
 						cmd2 = os.system("echo '# Kali linux repositories | Added by Katoolin\ndeb http://http.kali.org/kali kali-rolling main contrib non-free' >> /etc/apt/sources.list")
 					elif repo == "2":
 						cmd3 = os.system("apt-get update -m")

--- a/katoolin.py
+++ b/katoolin.py
@@ -46,8 +46,9 @@ def main():
 					''')
 					repo = raw_input("\033[1;32mWhat do you want to do ?> \033[1;m")
 					if repo == "1":
-						cmd1 = os.system("apt-key adv --keyserver hkp://keys.gnupg.net --recv-keys 7D8D0BF6")
-						cmd2 = os.system("echo '# Kali linux repositories | Added by Katoolin\ndeb http://http.kali.org/kali kali-rolling main contrib non-free' >> /etc/apt/sources.list")
+						cmd1 = os.system("wget https://http.kali.org/kali/pool/main/k/kali-archive-keyring/kali-archive-keyring_2018.1_all.deb")
++                                               cmd2 = os.system("sudo apt install ./kali-archive-keyring_2018.1_all.deb")
++						cmd3 = os.system("sudo echo '# Kali linux repositories | Added by Katoolin\ndeb http://http.kali.org/kali kali-rolling main contrib non-free' >> /etc/apt/sources.list")
 					elif repo == "2":
 						cmd3 = os.system("apt-get update -m")
 					elif repo == "3":


### PR DESCRIPTION
Keyring is out of date and script fails on execution.

This is the update. 

See [Raxgahrax/katoolin](https://github.com/Raxgahrax/katoolin/commit/c7ae11bd006f2dea58a9a89742c67620ab9491dc) for original commit (French)