### PR TITLE
key server problem fixed

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -46,7 +46,7 @@ def main():
 					''')
 					repo = raw_input("\033[1;32mWhat do you want to do ?> \033[1;m")
 					if repo == "1":
-						cmd1 = os.system("apt-key adv --keyserver pgp.mit.edu --recv-keys ED444FF07D8D0BF6")
+						cmd1 = os.system("apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED444FF07D8D0BF6")
 						cmd2 = os.system("echo '# Kali linux repositories | Added by Katoolin\ndeb http://http.kali.org/kali kali-rolling main contrib non-free' >> /etc/apt/sources.list")
 					elif repo == "2":
 						cmd3 = os.system("apt-get update -m")


### PR DESCRIPTION
seems like if you use old key server (pgp.mit.edu) and try to install kali repositories, you might get error info like:
"key server received failed"
and I just change the server in line 49 and it works for me (VM pro 14 workstation, Ubuntu16.04)