### PR TITLE
checks if user is running as root, or else aborts

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -3,6 +3,10 @@
 import os
 import sys, traceback
 
+
+if os.getuid() != 0:
+	print "Sorry. This script requires sudo privledges"
+	sys.exit()
 def main():
 	try:
 		print ('''


### PR DESCRIPTION
I think that this would be very helpful because bassically anything that you need to do in this tool requires sudo privledges, rejecting them at the start would be a better error message than 

`
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)`
`E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
`