### PR TITLE
Fault-tolerant package installation with bash for loop

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -11,10 +11,10 @@ def main():
 	try:
 		print ('''
 
- $$\   $$\             $$\                         $$\ $$\           
- $$ | $$  |            $$ |                        $$ |\__|          
- $$ |$$  /  $$$$$$\  $$$$$$\    $$$$$$\   $$$$$$\  $$ |$$\ $$$$$$$\  
- $$$$$  /   \____$$\ \_$$  _|  $$  __$$\ $$  __$$\ $$ |$$ |$$  __$$\ 
+ $$\   $$\             $$\                         $$\ $$\
+ $$ | $$  |            $$ |                        $$ |\__|
+ $$ |$$  /  $$$$$$\  $$$$$$\    $$$$$$\   $$$$$$\  $$ |$$\ $$$$$$$\
+ $$$$$  /   \____$$\ \_$$  _|  $$  __$$\ $$  __$$\ $$ |$$ |$$  __$$\
  $$  $$<    $$$$$$$ |  \033[1;36mKali linux tools installer\033[1;m |$$ |$$ |$$ |  $$ |
  \033[1;36m$$ |\$$\  $$  __$$ |  $$ |$$\ $$ |  $$ |$$ |  $$ |$$ |$$ |$$ |  $$ |
  $$ | \$$\ \$$$$$$$ |  \$$$$  |\$$$$$$  |\$$$$$$  |$$ |$$ |$$ |  $$ |
@@ -30,7 +30,7 @@ def main():
 		def inicio1():
 			while True:
 				print ('''
-1) Add Kali repositories & Update 
+1) Add Kali repositories & Update
 2) View Categories
 3) Install classicmenu indicator
 4) Install Kali menu
@@ -39,7 +39,7 @@ def main():
 			''')
 
 				opcion0 = raw_input("\033[1;36mkat > \033[1;m")
-			
+
 				while opcion0 == "1":
 					print ('''
 1) Add kali linux repositories
@@ -79,11 +79,11 @@ def main():
 						print (file.read())
 
 					else:
-						print ("\033[1;31mSorry, that was an invalid command!\033[1;m") 					
-						
+						print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
+
 
 				if opcion0 == "3":
-					print (''' 
+					print ('''
 ClassicMenu Indicator is a notification area applet (application indicator) for the top panel of Ubuntu's Unity desktop environment.
 
 It provides a simple way to get a classic GNOME-style application menu for those who prefer this over the Unity dash menu.
@@ -103,7 +103,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 					if repo == "y":
 						cmd1 = os.system("apt-get install kali-menu")
 				elif opcion0 == "5":
-					print (''' 
+					print ('''
 ****************** +Commands+ ******************
 
 
@@ -126,7 +126,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 5) Sniffing & Spoofing				12) Reverse Engineering
 6) Maintaining Access				13) Hardware Hacking
 7) Reporting Tools 				14) Extra
-									
+
 0) All
 
 			 ''')
@@ -138,7 +138,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 						elif opcion1 == "gohome":
 							inicio1()
 						elif opcion1 == "0":
-							cmd = os.system("apt-get -f install acccheck ace-voip amap automater braa casefile cdpsnarf cisco-torch cookie-cadger copy-router-config dmitry dnmap dnsenum dnsmap dnsrecon dnstracer dnswalk dotdotpwn enum4linux enumiax exploitdb fierce firewalk fragroute fragrouter ghost-phisher golismero goofile lbd maltego-teeth masscan metagoofil miranda nmap p0f parsero recon-ng set smtp-user-enum snmpcheck sslcaudit sslsplit sslstrip sslyze thc-ipv6 theharvester tlssled twofi urlcrazy wireshark wol-e xplico ismtp intrace hping3 bbqsql bed cisco-auditing-tool cisco-global-exploiter cisco-ocs cisco-torch copy-router-config doona dotdotpwn greenbone-security-assistant hexorbase jsql lynis nmap ohrwurm openvas-cli openvas-manager openvas-scanner oscanner powerfuzzer sfuzz sidguesser siparmyknife sqlmap sqlninja sqlsus thc-ipv6 tnscmd10g unix-privesc-check yersinia aircrack-ng asleap bluelog blueranger bluesnarfer bully cowpatty crackle eapmd5pass fern-wifi-cracker ghost-phisher giskismet gqrx kalibrate-rtl killerbee kismet mdk3 mfcuk mfoc mfterm multimon-ng pixiewps reaver redfang spooftooph wifi-honey wifitap wifite apache-users arachni bbqsql blindelephant burpsuite cutycapt davtest deblaze dirb dirbuster fimap funkload grabber jboss-autopwn joomscan jsql maltego-teeth padbuster paros parsero plecost powerfuzzer proxystrike recon-ng skipfish sqlmap sqlninja sqlsus ua-tester uniscan vega w3af webscarab websploit wfuzz wpscan xsser zaproxy burpsuite dnschef fiked hamster-sidejack hexinject iaxflood inviteflood ismtp mitmproxy ohrwurm protos-sip rebind responder rtpbreak rtpinsertsound rtpmixsound sctpscan siparmyknife sipp sipvicious sniffjoke sslsplit sslstrip thc-ipv6 voiphopper webscarab wifi-honey wireshark xspy yersinia zaproxy cryptcat cymothoa dbd dns2tcp http-tunnel httptunnel intersect nishang polenum powersploit pwnat ridenum sbd u3-pwn webshells weevely casefile cutycapt dos2unix dradis keepnote magictree metagoofil nipper-ng pipal armitage backdoor-factory cisco-auditing-tool cisco-global-exploiter cisco-ocs cisco-torch crackle jboss-autopwn linux-exploit-suggester maltego-teeth set shellnoob sqlmap thc-ipv6 yersinia beef-xss binwalk bulk-extractor chntpw cuckoo dc3dd ddrescue dumpzilla extundelete foremost galleta guymager iphone-backup-analyzer p0f pdf-parser pdfid pdgmail peepdf volatility xplico dhcpig funkload iaxflood inviteflood ipv6-toolkit mdk3 reaver rtpflood slowhttptest t50 termineter thc-ipv6 thc-ssl-dos acccheck burpsuite cewl chntpw cisco-auditing-tool cmospwd creddump crunch findmyhash gpp-decrypt hash-identifier hexorbase john johnny keimpx maltego-teeth maskprocessor multiforcer ncrack oclgausscrack pack patator polenum rainbowcrack rcracki-mt rsmangler statsprocessor thc-pptp-bruter truecrack webscarab wordlists zaproxy apktool dex2jar python-distorm3 edb-debugger jad javasnoop jd ollydbg smali valgrind yara android-sdk apktool arduino dex2jar sakis3g smali && wget http://www.morningstarsecurity.com/downloads/bing-ip2hosts-0.4.tar.gz && tar -xzvf bing-ip2hosts-0.4.tar.gz && cp bing-ip2hosts-0.4/bing-ip2hosts /usr/local/bin/")	
+							cmd = os.system("for apackage in acccheck ace-voip amap automater braa casefile cdpsnarf cisco-torch cookie-cadger copy-router-config dmitry dnmap dnsenum dnsmap dnsrecon dnstracer dnswalk dotdotpwn enum4linux enumiax exploitdb fierce firewalk fragroute fragrouter ghost-phisher golismero goofile lbd maltego-teeth masscan metagoofil miranda nmap p0f parsero recon-ng set smtp-user-enum snmpcheck sslcaudit sslsplit sslstrip sslyze thc-ipv6 theharvester tlssled twofi urlcrazy wireshark wol-e xplico ismtp intrace hping3 bbqsql bed cisco-auditing-tool cisco-global-exploiter cisco-ocs cisco-torch copy-router-config doona dotdotpwn greenbone-security-assistant hexorbase jsql lynis nmap ohrwurm openvas-cli openvas-manager openvas-scanner oscanner powerfuzzer sfuzz sidguesser siparmyknife sqlmap sqlninja sqlsus thc-ipv6 tnscmd10g unix-privesc-check yersinia aircrack-ng asleap bluelog blueranger bluesnarfer bully cowpatty crackle eapmd5pass fern-wifi-cracker ghost-phisher giskismet gqrx kalibrate-rtl killerbee kismet mdk3 mfcuk mfoc mfterm multimon-ng pixiewps reaver redfang spooftooph wifi-honey wifitap wifite apache-users arachni bbqsql blindelephant burpsuite cutycapt davtest deblaze dirb dirbuster fimap funkload grabber jboss-autopwn joomscan jsql maltego-teeth padbuster paros parsero plecost powerfuzzer proxystrike recon-ng skipfish sqlmap sqlninja sqlsus ua-tester uniscan vega w3af webscarab websploit wfuzz wpscan xsser zaproxy burpsuite dnschef fiked hamster-sidejack hexinject iaxflood inviteflood ismtp mitmproxy ohrwurm protos-sip rebind responder rtpbreak rtpinsertsound rtpmixsound sctpscan siparmyknife sipp sipvicious sniffjoke sslsplit sslstrip thc-ipv6 voiphopper webscarab wifi-honey wireshark xspy yersinia zaproxy cryptcat cymothoa dbd dns2tcp http-tunnel httptunnel intersect nishang polenum powersploit pwnat ridenum sbd u3-pwn webshells weevely casefile cutycapt dos2unix dradis keepnote magictree metagoofil nipper-ng pipal armitage backdoor-factory cisco-auditing-tool cisco-global-exploiter cisco-ocs cisco-torch crackle jboss-autopwn linux-exploit-suggester maltego-teeth set shellnoob sqlmap thc-ipv6 yersinia beef-xss binwalk bulk-extractor chntpw cuckoo dc3dd ddrescue dumpzilla extundelete foremost galleta guymager iphone-backup-analyzer p0f pdf-parser pdfid pdgmail peepdf volatility xplico dhcpig funkload iaxflood inviteflood ipv6-toolkit mdk3 reaver rtpflood slowhttptest t50 termineter thc-ipv6 thc-ssl-dos acccheck burpsuite cewl chntpw cisco-auditing-tool cmospwd creddump crunch findmyhash gpp-decrypt hash-identifier hexorbase john johnny keimpx maltego-teeth maskprocessor multiforcer ncrack oclgausscrack pack patator polenum rainbowcrack rcracki-mt rsmangler statsprocessor thc-pptp-bruter truecrack webscarab wordlists zaproxy apktool dex2jar python-distorm3 edb-debugger jad javasnoop jd ollydbg smali valgrind yara android-sdk apktool arduino dex2jar sakis3g smali; do apt-get -f $apackage; done; && wget http://www.morningstarsecurity.com/downloads/bing-ip2hosts-0.4.tar.gz && tar -xzvf bing-ip2hosts-0.4.tar.gz && cp bing-ip2hosts-0.4/bing-ip2hosts /usr/local/bin/")
 						while opcion1 == "1":
 							print ('''
 \033[1;36m=+[ Information Gathering\033[1;m
@@ -174,7 +174,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 29) goofile
 
 0) Install all Information Gathering tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -297,9 +297,9 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()		
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y acccheck ace-voip amap automater braa casefile cdpsnarf cisco-torch cookie-cadger copy-router-config dmitry dnmap dnsenum dnsmap dnsrecon dnstracer dnswalk dotdotpwn enum4linux enumiax exploitdb fierce firewalk fragroute fragrouter ghost-phisher golismero goofile lbd maltego-teeth masscan metagoofil miranda nmap p0f parsero recon-ng set smtp-user-enum snmpcheck sslcaudit sslsplit sslstrip sslyze thc-ipv6 theharvester tlssled twofi urlcrazy wireshark wol-e xplico ismtp intrace hping3 && wget http://www.morningstarsecurity.com/downloads/bing-ip2hosts-0.4.tar.gz && tar -xzvf bing-ip2hosts-0.4.tar.gz && cp bing-ip2hosts-0.4/bing-ip2hosts /usr/local/bin/")				
+								cmd = os.system("for apackage in acccheck ace-voip amap automater braa casefile cdpsnarf cisco-torch cookie-cadger copy-router-config dmitry dnmap dnsenum dnsmap dnsrecon dnstracer dnswalk dotdotpwn enum4linux enumiax exploitdb fierce firewalk fragroute fragrouter ghost-phisher golismero goofile lbd maltego-teeth masscan metagoofil miranda nmap p0f parsero recon-ng set smtp-user-enum snmpcheck sslcaudit sslsplit sslstrip sslyze thc-ipv6 theharvester tlssled twofi urlcrazy wireshark wol-e xplico ismtp intrace hping3; do apt-get install -y $apackage; done; && wget http://www.morningstarsecurity.com/downloads/bing-ip2hosts-0.4.tar.gz && tar -xzvf bing-ip2hosts-0.4.tar.gz && cp bing-ip2hosts-0.4/bing-ip2hosts /usr/local/bin/")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 
@@ -329,7 +329,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 					35) Yersinia
 
 0) Install all Vulnerability Analysis tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -408,9 +408,9 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()						
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y bbqsql bed cisco-auditing-tool cisco-global-exploiter cisco-ocs cisco-torch copy-router-config doona dotdotpwn greenbone-security-assistant hexorbase jsql lynis nmap ohrwurm openvas-cli openvas-manager openvas-scanner oscanner powerfuzzer sfuzz sidguesser siparmyknife sqlmap sqlninja sqlsus thc-ipv6 tnscmd10g unix-privesc-check yersinia")						
+								cmd = os.system("for apackage in bbqsql bed cisco-auditing-tool cisco-global-exploiter cisco-ocs cisco-torch copy-router-config doona dotdotpwn greenbone-security-assistant hexorbase jsql lynis nmap ohrwurm openvas-cli openvas-manager openvas-scanner oscanner powerfuzzer sfuzz sidguesser siparmyknife sqlmap sqlninja sqlsus thc-ipv6 tnscmd10g unix-privesc-check yersinia; do apt-get install -y $apackage; done;")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 
@@ -432,10 +432,10 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 12) Fern Wifi Cracker			28) RTLSDR Scanner
 13) Ghost Phisher			29) Spooftooph
 14) GISKismet				30) Wifi Honey				31) Wifitap
-16) gr-scan				32) Wifite 
+16) gr-scan				32) Wifite
 
 0) Install all Wireless Attacks tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -504,11 +504,11 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "32":
 								cmd = os.system("apt-get install wifite")
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y aircrack-ng asleap bluelog blueranger bluesnarfer bully cowpatty crackle eapmd5pass fern-wifi-cracker ghost-phisher giskismet gqrx kalibrate-rtl killerbee kismet mdk3 mfcuk mfoc mfterm multimon-ng pixiewps reaver redfang spooftooph wifi-honey wifitap wifite")
+								cmd = os.system("for apackage in aircrack-ng asleap bluelog blueranger bluesnarfer bully cowpatty crackle eapmd5pass fern-wifi-cracker ghost-phisher giskismet gqrx kalibrate-rtl killerbee kismet mdk3 mfcuk mfoc mfterm multimon-ng pixiewps reaver redfang spooftooph wifi-honey wifitap wifite; apt-get install -y $apackage; done;")
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()						
+								inicio1()
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 						while opcion1 == "4":
@@ -538,11 +538,11 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 					41) zaproxy
 
 0) Install all Web Applications tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 
-							
+
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
 							if opcion2 == "1":
 								cmd = os.system("apt-get install apache-users")
@@ -627,13 +627,13 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "40":
 								cmd = os.system("apt-get install xsser")
 							elif opcion2 == "41":
-								cmd = os.system("apt-get install zaproxy")										
+								cmd = os.system("apt-get install zaproxy")
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()	
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y apache-users arachni bbqsql blindelephant burpsuite cutycapt davtest deblaze dirb dirbuster fimap funkload grabber jboss-autopwn joomscan jsql maltego-teeth padbuster paros parsero plecost powerfuzzer proxystrike recon-ng skipfish sqlmap sqlninja sqlsus ua-tester uniscan vega w3af webscarab websploit wfuzz wpscan xsser zaproxy")												
+								cmd = os.system("for apackage in apache-users arachni bbqsql blindelephant burpsuite cutycapt davtest deblaze dirb dirbuster fimap funkload grabber jboss-autopwn joomscan jsql maltego-teeth padbuster paros parsero plecost powerfuzzer proxystrike recon-ng skipfish sqlmap sqlninja sqlsus ua-tester uniscan vega w3af webscarab websploit wfuzz wpscan xsser zaproxy; do apt-get install -y $apackage; done;")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 						while opcion1 == "5":
@@ -655,10 +655,10 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 13) rebind				29) Wireshark
 14) responder				30) xspy
 15) rtpbreak				31) Yersinia
-16) rtpinsertsound			32) zaproxy 
+16) rtpinsertsound			32) zaproxy
 
 0) Install all Sniffing & Spoofing tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -735,7 +735,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 
 
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y burpsuite dnschef fiked hamster-sidejack hexinject iaxflood inviteflood ismtp mitmproxy ohrwurm protos-sip rebind responder rtpbreak rtpinsertsound rtpmixsound sctpscan siparmyknife sipp sipvicious sniffjoke sslsplit sslstrip thc-ipv6 voiphopper webscarab wifi-honey wireshark xspy yersinia zaproxy")  
+								cmd = os.system("for apackage in burpsuite dnschef fiked hamster-sidejack hexinject iaxflood inviteflood ismtp mitmproxy ohrwurm protos-sip rebind responder rtpbreak rtpinsertsound rtpmixsound sctpscan siparmyknife sipp sipvicious sniffjoke sslsplit sslstrip thc-ipv6 voiphopper webscarab wifi-honey wireshark xspy yersinia zaproxy; do apt-get install -y $apackage; done;")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 
@@ -747,7 +747,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
  2) Cymothoa
  3) dbd
  4) dns2tcp
- 5) http-tunnel	
+ 5) http-tunnel
  6) HTTPTunnel
  7) Intersect
  8) Nishang
@@ -761,7 +761,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 16) Weevely
 
 0) Install all Maintaining Access tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -802,9 +802,9 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()   
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y cryptcat cymothoa dbd dns2tcp http-tunnel httptunnel intersect nishang polenum powersploit pwnat ridenum sbd u3-pwn webshells weevely")
+								cmd = os.system("for apackage in cryptcat cymothoa dbd dns2tcp http-tunnel httptunnel intersect nishang polenum powersploit pwnat ridenum sbd u3-pwn webshells weevely; do apt-get install -y $apackage; done")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 						while opcion1 == "7":
@@ -815,14 +815,14 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 2) CutyCapt
 3) dos2unix
 4) Dradis
-5) KeepNote	
+5) KeepNote
 6) MagicTree
 7) Metagoofil
 8) Nipper-ng
 9) pipal
 
 0) Install all Reporting Tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -849,9 +849,9 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()   
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y casefile cutycapt dos2unix dradis keepnote magictree metagoofil nipper-ng pipal")  
+								cmd = os.system("for apackage in casefile cutycapt dos2unix dradis keepnote magictree metagoofil nipper-ng pipal do apt-get install -y $apackage; done;")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 
@@ -863,7 +863,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
  2) Backdoor Factory
  3) BeEF
  4) cisco-auditing-tool
- 5) cisco-global-exploiter	
+ 5) cisco-global-exploiter
  6) cisco-ocs
  7) cisco-torch
  8) commix
@@ -878,7 +878,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 17) Yersinia
 
 0) Install all Exploitation Tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -921,9 +921,9 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()   
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y armitage backdoor-factory cisco-auditing-tool cisco-global-exploiter cisco-ocs cisco-torch crackle jboss-autopwn linux-exploit-suggester maltego-teeth set shellnoob sqlmap thc-ipv6 yersinia beef-xss")  						
+								cmd = os.system("for apackage in armitage backdoor-factory cisco-auditing-tool cisco-global-exploiter cisco-ocs cisco-torch crackle jboss-autopwn linux-exploit-suggester maltego-teeth set shellnoob sqlmap thc-ipv6 yersinia beef-xss; do apt-get install -y $apackage; done")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 
@@ -946,7 +946,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 					23) Xplico
 
 0) Install all Forensics Tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -1001,9 +1001,9 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()   
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y binwalk bulk-extractor chntpw cuckoo dc3dd ddrescue dumpzilla extundelete foremost galleta guymager iphone-backup-analyzer p0f pdf-parser pdfid pdgmail peepdf volatility xplico")						
+								cmd = os.system("for apackage in binwalk bulk-extractor chntpw cuckoo dc3dd ddrescue dumpzilla extundelete foremost galleta guymager iphone-backup-analyzer p0f pdf-parser pdfid pdgmail peepdf volatility xplico; do apt-get install -y $apackage; done;")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 						while opcion1 == "10":
@@ -1014,7 +1014,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
  2) FunkLoad
  3) iaxflood
  4) Inundator
- 5) inviteflood	
+ 5) inviteflood
  6) ipv6-toolkit
  7) mdk3
  8) Reaver
@@ -1023,10 +1023,10 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 11) t50
 12) Termineter
 13) THC-IPV6
-14) THC-SSL-DOS 		
+14) THC-SSL-DOS
 
 0) Install all Stress Testing tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -1059,13 +1059,13 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "13":
 								cmd = os.system("apt-get install thc-ipv6")
 							elif opcion2 == "14":
-								cmd = os.system("apt-get install thc-ssl-dos ")    				             										
+								cmd = os.system("apt-get install thc-ssl-dos ")
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()   
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y dhcpig funkload iaxflood inviteflood ipv6-toolkit mdk3 reaver rtpflood slowhttptest t50 termineter thc-ipv6 thc-ssl-dos")
+								cmd = os.system("for apackage in dhcpig funkload iaxflood inviteflood ipv6-toolkit mdk3 reaver rtpflood slowhttptest t50 termineter thc-ipv6 thc-ssl-dos; do apt-get install -y $apackage; done;")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 						while opcion1 == "11":
@@ -1087,12 +1087,12 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 13) HexorBase				31) Statsprocessor
 14) THC-Hydra				32) THC-pptp-bruter
 15) John the Ripper			33) TrueCrack
-16) Johnny				34) WebScarab 
-17) keimpx				35) wordlists 
-18) Maltego Teeth			36) zaproxy 
+16) Johnny				34) WebScarab
+17) keimpx				35) wordlists
+18) Maltego Teeth			36) zaproxy
 
 0) Install all Password Attacks tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -1173,9 +1173,9 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()   
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y acccheck burpsuite cewl chntpw cisco-auditing-tool cmospwd creddump crunch findmyhash gpp-decrypt hash-identifier hexorbase john johnny keimpx maltego-teeth maskprocessor multiforcer ncrack oclgausscrack pack patator polenum rainbowcrack rcracki-mt rsmangler statsprocessor thc-pptp-bruter truecrack webscarab wordlists zaproxy")
+								cmd = os.system("for apackage in acccheck burpsuite cewl chntpw cisco-auditing-tool cmospwd creddump crunch findmyhash gpp-decrypt hash-identifier hexorbase john johnny keimpx maltego-teeth maskprocessor multiforcer ncrack oclgausscrack pack patator polenum rainbowcrack rcracki-mt rsmangler statsprocessor thc-pptp-bruter truecrack webscarab wordlists zaproxy; do apt-get install -y $apackage; done;")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 						while opcion1 == "12" :
@@ -1186,7 +1186,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
  2) dex2jar
  3) diStorm3
  4) edb-debugger
- 5) jad	
+ 5) jad
  6) javasnoop
  7) JD-GUI
  8) OllyDbg
@@ -1195,7 +1195,7 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 11) YARA
 
 0) Install all Reverse Engineering tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -1226,9 +1226,9 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()   
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y apktool dex2jar python-diStorm3 edb-debugger jad javasnoop JD OllyDbg smali Valgrind YARA")
+								cmd = os.system("for apackage in apktool dex2jar python-diStorm3 edb-debugger jad javasnoop JD OllyDbg smali Valgrind YARA; do apt-get install -y $apackage; done;")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 						while opcion1 == "13" :
@@ -1239,11 +1239,11 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
  2) apktool
  3) Arduino
  4) dex2jar
- 5) Sakis3G	
+ 5) Sakis3G
  6) smali
 
 0) Install all Hardware Hacking tools
-				 
+
 						''')
 							print ("\033[1;32mInsert the number of the tool to install it .\n\033[1;m")
 							opcion2 = raw_input("\033[1;36mkat > \033[1;m")
@@ -1265,9 +1265,9 @@ For more information , please visit : http://www.florian-diesch.de/software/clas
 							elif opcion2 == "back":
 								inicio()
 							elif opcion2 == "gohome":
-								inicio1()   
+								inicio1()
 							elif opcion2 == "0":
-								cmd = os.system("apt-get install -y android-sdk apktool arduino dex2jar sakis3g smali")
+								cmd = os.system("for apackage in android-sdk apktool arduino dex2jar sakis3g smali; apt-get install -y $apackage; done;")
 							else:
 								print ("\033[1;31mSorry, that was an invalid command!\033[1;m")
 						while opcion1 == "14" :


### PR DESCRIPTION
Scenario:
In the current version, if any singular package to be installed is missing or can't be found, the entire installation (including all other packages) will fail. This is because if apt-get is given a list of packages and one can't be installed, it assumes the entire command is invalid and shuts down. 

Fix:
Instead of passing apt-get a list of packages to be installed, instead use a for loop to iterate over a list, installing each package by itself individually. This is much more robust, and if any individual install fails it has no effect on any other package installs. I've used this technique in my own install scripts to great success: [https://github.com/mkrupczak3/gettools](https://github.com/mkrupczak3/gettools)

Note:
Due to my IDE settings a bunch of whitespace has been mangled. My first change is on line 302, and any further changes are on any lines that have "opcion 2 == "0"" on them.

@LionSec Really like this tool, thanks!