### PR TITLE
Fetch keys over port 80 by default

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -50,7 +50,7 @@ def main():
 					''')
 					repo = raw_input("\033[1;32mWhat do you want to do ?> \033[1;m")
 					if repo == "1":
-						cmd1 = os.system("apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED444FF07D8D0BF6")
+						cmd1 = os.system("apt-key adv --keyserver pool.sks-keyservers.net:80 --recv-keys ED444FF07D8D0BF6")
 						cmd2 = os.system("echo '# Kali linux repositories | Added by Katoolin\ndeb http://http.kali.org/kali kali-rolling main contrib non-free' >> /etc/apt/sources.list")
 					elif repo == "2":
 						cmd3 = os.system("apt-get update -m")


### PR DESCRIPTION
Receiving the keys over the default port 11371 doesn't work for most users behind a firewall.
https://unix.stackexchange.com/questions/399027/gpg-keyserver-receive-failed-server-indicated-a-failure