### PR TITLE
Fix errors in katoolin.py (Manjaro & Ubuntu)

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -5,7 +5,7 @@ import sys, traceback
 
 
 if os.getuid() != 0:
-	print "Sorry. This script requires sudo privledges"
+	print ("Sorry. This script requires sudo privledges")
 	sys.exit()
 def main():
 	try:


### PR DESCRIPTION
File "/bin/katoolin", line 8
    print "Sorry. This script requires sudo privledges"
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("Sorry. This script requires sudo privledges")?