### PR TITLE
Added parens to print on line 8 - need root error

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -5,7 +5,7 @@ import sys, traceback
 
 
 if os.getuid() != 0:
-	print "Sorry. This script requires sudo privledges"
+	print("Sorry. This script requires sudo privledges")
 	sys.exit()
 def main():
 	try:


### PR DESCRIPTION
Python kicks a SyntaxError upon reaching:
Line 8:        print "Sorry. This script requires sudo privledges"

Wrapping parens around both double-quotes removes error.