### PR TITLE
Changes on the server for the katoolin.py

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -50,7 +50,7 @@ def main():
 					''')
 					repo = raw_input("\033[1;32mWhat do you want to do ?> \033[1;m")
 					if repo == "1":
-						cmd1 = os.system("apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED444FF07D8D0BF6")
+						cmd1 = os.system("apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ED444FF07D8D0BF6")
 						cmd2 = os.system("echo '# Kali linux repositories | Added by Katoolin\ndeb http://http.kali.org/kali kali-rolling main contrib non-free' >> /etc/apt/sources.list")
 					elif repo == "2":
 						cmd3 = os.system("apt-get update -m")


### PR DESCRIPTION
A few changes were made concerning the server.
This --keyserver pool.sks-keyservers.net has been interchanged and instead this --keyserver keyserver.ubuntu.com was used

SKS keyservers are deprecated and most of them are going offline. As such you will not be able to retrieve keys from them.