### PR TITLE
Update katoolin.py

### DIFF
--- a/katoolin.py
+++ b/katoolin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
 
 import os
 import sys, traceback


### PR DESCRIPTION
Added "2.7" to line :1 to specify the interpreter and avoid "unable" errors.